### PR TITLE
Update driver methods to represent queue semantics

### DIFF
--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -12,7 +12,7 @@ interface DriverInterface
      *
      * @return bool
      */
-    public function push($queue, $message);
+    public function enqueue($queue, $message);
 
     /**
      * Retrieve a message from the queue
@@ -21,5 +21,5 @@ interface DriverInterface
      *
      * @return string
      */
-    public function pop($queue);
+    public function dequeue($queue);
 }

--- a/src/Driver/RedisDriver.php
+++ b/src/Driver/RedisDriver.php
@@ -22,7 +22,7 @@ class RedisDriver implements DriverInterface
     /**
      * @inheritdoc
      */
-    public function push($queue, $message)
+    public function enqueue($queue, $message)
     {
         return (bool) $this->redis->rPush($queue, $message);
     }
@@ -30,7 +30,7 @@ class RedisDriver implements DriverInterface
     /**
      * @inheritdoc
      */
-    public function pop($queue)
+    public function dequeue($queue)
     {
         list($_, $message) = $this->redis->blPop($queue, 5) ?: null;
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -37,7 +37,7 @@ class Queue
      */
     public function add(Message $message)
     {
-        return $this->driver->push(
+        return $this->driver->enqueue(
             $message->queue(),
             $this->serializer->serialize($message)
         );

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -67,7 +67,7 @@ class Worker
      */
     private function tick($queue)
     {
-        $packet = $this->driver->pop($queue);
+        $packet = $this->driver->dequeue($queue);
         if (empty($packet)) {
              return true;
         }

--- a/tests/Driver/RedisDriverTest.php
+++ b/tests/Driver/RedisDriverTest.php
@@ -34,7 +34,7 @@ class RedisDriverTest extends TestCase
             ->with($queue, $message)
             ->willReturn(true);
 
-        $this->assertTrue($this->driver->push($queue, $message));
+        $this->assertTrue($this->driver->enqueue($queue, $message));
     }
 
     public function testPop()
@@ -47,7 +47,7 @@ class RedisDriverTest extends TestCase
             ->with($queue, 5)
             ->willReturn(['test', 'example']);
 
-        $this->assertSame('example', $this->driver->pop($queue));
+        $this->assertSame('example', $this->driver->dequeue($queue));
     }
 
     public function testPopEmpty()
@@ -60,6 +60,6 @@ class RedisDriverTest extends TestCase
             ->with($queue, 5)
             ->willReturn(null);
 
-        $this->assertNull($this->driver->pop($queue));
+        $this->assertNull($this->driver->dequeue($queue));
     }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -40,7 +40,7 @@ class QueueTest extends TestCase
 
         $this->driver
             ->expects($this->once())
-            ->method('push')
+            ->method('enqueue')
             ->with('queue', $serialized_message)
             ->willReturn(true);
 

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -76,7 +76,7 @@ class WorkerTest extends TestCase
         $queue = 'test-queue';
         $this->driver
             ->expects($this->once())
-            ->method('pop')
+            ->method('dequeue')
             ->with($queue)
             ->willReturn(null);
 
@@ -94,7 +94,7 @@ class WorkerTest extends TestCase
 
         $this->driver
             ->expects($this->once())
-            ->method('pop')
+            ->method('dequeue')
             ->with($message['queue'])
             ->willReturn(json_encode($message));
 
@@ -109,7 +109,7 @@ class WorkerTest extends TestCase
 
         $this->driver
             ->expects($this->once())
-            ->method('pop')
+            ->method('dequeue')
             ->with($message->queue())
             ->willReturn($this->serializer->serialize($message));
 
@@ -135,7 +135,7 @@ class WorkerTest extends TestCase
 
         $this->driver
             ->expects($this->once())
-            ->method('pop')
+            ->method('dequeue')
             ->with($message->queue())
             ->willReturn($this->serializer->serialize($message));
 
@@ -161,7 +161,7 @@ class WorkerTest extends TestCase
 
         $this->driver
             ->expects($this->once())
-            ->method('pop')
+            ->method('dequeue')
             ->with($message->queue())
             ->willReturn($this->serializer->serialize($message));
 
@@ -191,7 +191,7 @@ class WorkerTest extends TestCase
 
         $this->driver
             ->expects($this->once())
-            ->method('pop')
+            ->method('dequeue')
             ->with($message->queue())
             ->willReturn($this->serializer->serialize($message));
 


### PR DESCRIPTION
Because it's a f'ing queue, not a stack.
