### PR TITLE
Get the actual command name

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -42,7 +42,7 @@ class Event
     public function acknowledge($command)
     {
         $this->emitter->emit(static::MESSAGE_ACKNOWLEDGE, $command);
-        $this->logger->info(sprintf('`%s` job started', get_class($command)));
+        $this->logger->info(sprintf('`%s` job started', get_class($command->command())));
     }
 
     /**
@@ -53,7 +53,7 @@ class Event
     public function finish($command)
     {
         $this->emitter->emit(static::MESSAGE_FINISH, $command);
-        $this->logger->info(sprintf('`%s` job finished', get_class($command)));
+        $this->logger->info(sprintf('`%s` job finished', get_class($command->command())));
     }
 
     /**

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -34,7 +34,7 @@ class EventTest extends TestCase
         $this->emitter = $this->createMock(EmitterInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->event = new Event($this->emitter, $this->logger);
-        $this->command = new Command;
+        $this->command = new QueuedCommand(new Command);
     }
 
     public function testAcknowledge()


### PR DESCRIPTION
I forgot that the actual command was encapsulated within the `QueuedCommand` object.
