### PR TITLE
Add beanstalk driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "eloquent/liberator": "^2.0",
-        "eloquent/phony": "^0.13.4",
+        "eloquent/phony": "0.13.4",
         "monolog/monolog": "^1.21",
         "pda/pheanstalk": "^3.1",
         "phpunit/phpunit": "^5.4"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "eloquent/liberator": "^2.0",
         "eloquent/phony": "^0.13.4",
         "monolog/monolog": "^1.21",
+        "pda/pheanstalk": "^3.1",
         "phpunit/phpunit": "^5.4"
     },
     "suggest": {

--- a/src/Driver/BeanstalkDriver.php
+++ b/src/Driver/BeanstalkDriver.php
@@ -38,7 +38,7 @@ class BeanstalkDriver implements DriverInterface
         $job = $this->beanstalk
             ->watch($queue)
             ->ignore('default')
-            ->reserve(5);
+            ->reserve(static::TIMEOUT);
 
         $data = $job instanceof Job ? $job->getData() : $job;
         return [

--- a/src/Driver/BeanstalkDriver.php
+++ b/src/Driver/BeanstalkDriver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Equip\Queue\Driver;
+
+use Pheanstalk\Job;
+use Pheanstalk\Pheanstalk;
+
+class BeanstalkDriver implements DriverInterface
+{
+    /**
+     * @var Pheanstalk
+     */
+    private $beanstalk;
+
+    /**
+     * @param Pheanstalk $beanstalk
+     */
+    public function __construct(Pheanstalk $beanstalk)
+    {
+        $this->beanstalk = $beanstalk;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function enqueue($queue, $command)
+    {
+        return (boolean) $this->beanstalk
+            ->useTube($queue)
+            ->put(serialize($command));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dequeue($queue)
+    {
+        $job = $this->beanstalk
+            ->watch($queue)
+            ->ignore('default')
+            ->reserve(5);
+
+        $data = $job instanceof Job ? $job->getData() : $job;
+        return [
+            unserialize($data),
+            $job,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function processed($job)
+    {
+        return (boolean) $this->beanstalk->delete($job);
+    }
+}

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -22,4 +22,13 @@ interface DriverInterface
      * @return string
      */
     public function dequeue($queue);
+
+    /**
+     * Marks a job as processed
+     *
+     * @param mixed $job
+     *
+     * @return boolean
+     */
+    public function processed($job);
 }

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -4,6 +4,8 @@ namespace Equip\Queue\Driver;
 
 interface DriverInterface
 {
+    const TIMEOUT = 5;
+
     /**
      * Add a command to the queue
      *

--- a/src/Driver/RedisDriver.php
+++ b/src/Driver/RedisDriver.php
@@ -32,7 +32,7 @@ class RedisDriver implements DriverInterface
      */
     public function dequeue($queue)
     {
-        list($_, $message) = $this->redis->blPop($queue, static::TIMEOUT) ?: null;
+        list(, $message) = $this->redis->blPop($queue, static::TIMEOUT) ?: null;
 
         return [
             unserialize($message),

--- a/src/Driver/RedisDriver.php
+++ b/src/Driver/RedisDriver.php
@@ -32,7 +32,7 @@ class RedisDriver implements DriverInterface
      */
     public function dequeue($queue)
     {
-        list($_, $message) = $this->redis->blPop($queue, 5) ?: null;
+        list($_, $message) = $this->redis->blPop($queue, static::TIMEOUT) ?: null;
 
         return [
             unserialize($message),

--- a/src/Driver/RedisDriver.php
+++ b/src/Driver/RedisDriver.php
@@ -34,6 +34,17 @@ class RedisDriver implements DriverInterface
     {
         list($_, $message) = $this->redis->blPop($queue, 5) ?: null;
 
-        return $message;
+        return [
+            unserialize($message),
+            null,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function processed($job)
+    {
+        return true;
     }
 }

--- a/tests/Driver/BeanstalkDriverTest.php
+++ b/tests/Driver/BeanstalkDriverTest.php
@@ -101,7 +101,7 @@ class BeanstalkDriverTest extends TestCase
 
     public function testProcessed()
     {
-        $job = new \stdClass();
+        $job = new \stdClass;
 
         $this->beanstalk
             ->expects($this->once())

--- a/tests/Driver/BeanstalkDriverTest.php
+++ b/tests/Driver/BeanstalkDriverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Equip\Queue\Driver;
+
+use Equip\Queue\Fake\Command;
+use Equip\Queue\TestCase;
+use Pheanstalk\Job;
+use Pheanstalk\Pheanstalk;
+
+class BeanstalkDriverTest extends TestCase
+{
+    /**
+     * @var Pheanstalk
+     */
+    private $beanstalk;
+
+    /**
+     * @var BeanstalkDriver
+     */
+    private $driver;
+
+    protected function setUp()
+    {
+        $this->beanstalk = $this->createMock(Pheanstalk::class);
+        $this->driver = new BeanstalkDriver($this->beanstalk);
+    }
+
+    public function testQueue()
+    {
+        $command = new Command;
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('useTube')
+            ->with('test-queue')
+            ->willReturn($this->beanstalk);
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('put')
+            ->with(serialize($command))
+            ->willReturn(true);
+
+        $this->assertTrue($this->driver->enqueue('test-queue', $command));
+    }
+
+    public function testDequeue()
+    {
+        $command = new Command;
+        $job = new Job(1, serialize($command));
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('watch')
+            ->with('test-queue')
+            ->willReturn($this->beanstalk);
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('ignore')
+            ->with('default')
+            ->willReturn($this->beanstalk);
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('reserve')
+            ->with(5)
+            ->willReturn($job);
+
+        $this->assertEquals([
+            unserialize($job->getData()),
+            $job,
+        ], $this->driver->dequeue('test-queue'));
+    }
+
+    public function testDequeueEmpty()
+    {
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('watch')
+            ->with('test-queue')
+            ->willReturn($this->beanstalk);
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('ignore')
+            ->with('default')
+            ->willReturn($this->beanstalk);
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('reserve')
+            ->with(5)
+            ->willReturn(false);
+
+        $this->assertEquals([
+            false,
+            false,
+        ], $this->driver->dequeue('test-queue'));
+    }
+
+    public function testProcessed()
+    {
+        $job = new \stdClass();
+
+        $this->beanstalk
+            ->expects($this->once())
+            ->method('delete')
+            ->with($job)
+            ->willReturn(true);
+
+        $this->assertTrue($this->driver->processed($job));
+    }
+}

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -45,7 +45,7 @@ class WorkerTest extends TestCase
     public function testTick()
     {
         // Mock
-        $this->driver->dequeue->returns(serialize($this->command));
+        $this->driver->dequeue->returns([$this->command, null]);
 
         // Execute
         $result = $this->worker()->tick('test-queue');
@@ -54,6 +54,7 @@ class WorkerTest extends TestCase
         $this->driver->dequeue->calledWith('test-queue');
         $this->event->acknowledge->calledWith($this->command);
         $this->command_bus->handle->calledWith($this->command);
+        $this->driver->processed->calledWith(null);
         $this->event->finish->calledWith($this->command);
 
         $this->assertTrue($result);
@@ -63,7 +64,7 @@ class WorkerTest extends TestCase
     {
         // Mock
         $exception = new \Exception;
-        $this->driver->dequeue->returns(serialize($this->command));
+        $this->driver->dequeue->returns([$this->command, null]);
         $this->command_bus->handle->throws($exception);
 
         // Execute


### PR DESCRIPTION
Adds Beanstalk support using https://github.com/pda/pheanstalk

Also, added a method to mark jobs as processed to provide more reliable queues. The Redis driver will need to be updated to be more reliable in case of failures, such as network and memory related.
