### PR TITLE
Update control method visibility

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -128,7 +128,7 @@ class Worker
     /**
      * Set the worker to shutdown on the next tick
      */
-    private function shutdown()
+    public function shutdown()
     {
         $this->shutdown = true;
     }
@@ -136,7 +136,7 @@ class Worker
     /**
      * Set the worker to shutdown when the queue is drained
      */
-    private function drain()
+    public function drain()
     {
         $this->drain = true;
     }


### PR DESCRIPTION
Depending on the scope of the caller, the `pcntl_signal` function won't be able to access the private methods.
