### PR TITLE
Failed jobs weren't removed from the original queue

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -95,11 +95,12 @@ class Worker
         try {
             $this->event->acknowledge($command);
             $this->command_bus->handle($command);
-            $this->driver->processed($job);
             $this->event->finish($command);
         } catch (Exception $exception) {
             $this->queue->add(sprintf('%s-failed', $queue), $command);
             $this->event->reject($command, $exception);
+        } finally {
+            $this->driver->processed($job);
         }
 
         return true;

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -64,7 +64,8 @@ class WorkerTest extends TestCase
     {
         // Mock
         $exception = new \Exception;
-        $this->driver->dequeue->returns([$this->command, null]);
+        $job = new \stdClass();
+        $this->driver->dequeue->returns([$this->command, $job]);
         $this->command_bus->handle->throws($exception);
 
         // Execute
@@ -75,6 +76,7 @@ class WorkerTest extends TestCase
         $this->event->acknowledge->calledWith($this->command);
         $this->command_bus->handle->calledWith($this->command);
         $this->event->reject->calledWith($this->command, $exception);
+        $this->driver->processed->calledWith($job);
 
         $this->assertTrue($result);
     }


### PR DESCRIPTION
As the title states, if the command bus handler throws an exception the job is never marked as processed, which means it's never removed from the original queue.