### PR TITLE
Add exception context to monolog error reporting

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -2,7 +2,6 @@
 
 namespace Equip\Queue;
 
-use Equip\Command\OptionsInterface;
 use Exception;
 use League\Event\EmitterInterface;
 use Psr\Log\LoggerInterface;
@@ -66,7 +65,7 @@ class Event
     public function reject($command, Exception $exception)
     {
         $this->emitter->emit(static::MESSAGE_REJECT, $command, $exception);
-        $this->logger->error($exception->getMessage());
+        $this->logger->error($exception->getMessage(), compact('exception'));
     }
 
     /**


### PR DESCRIPTION
Basing on looking at the code for [`RollbarHandler`](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/RollbarHandler.php#L99-L103) and the [`RavenHandler`](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/RavenHandler.php#L185), this is the standard way to log an exception in Monolog.